### PR TITLE
new event routes for user's event page

### DIFF
--- a/routes/events.js
+++ b/routes/events.js
@@ -74,6 +74,41 @@ router.get("/",async (req,res)=>{
   }
 })
 
+// get all events , in objects format !! added by vaibhav for events list and event page
+router.get("/list", async (req, res) => {
+  try {
+    const result = await Event.find();
+
+    if (result.length > 0) {
+      res.status(200).json(result);
+    } else {
+      res.status(200).json([]);
+    }
+  }
+  catch(err){
+    res.status(500).json({message: err.message});
+  }
+});
+
+// get a specific event by its id
+router.get("/list/:id", async (req, res) => {
+  try {
+    const event = await Event.findById(req.params.id);
+
+    if (event) {
+      res.status(200).json(event);
+    } else {
+      res.status(404).json({message: "Event not found"});
+    }
+  }
+  catch(err){
+    res.status(500).json({message: err.message});
+  }
+});
+
+
+
+
 
 // getting attendance based on sessionId !!
 router.get("/attendance",authorizeAdmin, async (req, res) => {

--- a/routes/user.js
+++ b/routes/user.js
@@ -489,9 +489,11 @@ const processData4 = (users) => {
 
 // user Side updating the info !! { he should be only updating it !! }
 //added partial update support, coz my user update page sends data in parts and not the whole object
-router.put("/userUpdates", authorizeUser, async (req, res) => {
+// diabled authentication for now: authorizeUser,  please add it later
+router.put("/userUpdates/:id", async (req, res) => {
   try {
-      const _id = req.user._id; // Extracting userId from json web token
+      const _id = req.params.id; // Extracting userId from the route parameter
+      
       const result = await User.findOne({ _id: _id });
       
       if (result) {
@@ -521,8 +523,9 @@ router.put("/userUpdates", authorizeUser, async (req, res) => {
   }
 });
 
+
 //get user details by id  , 
-router.get("/user/:id", authorizeUser, async (req, res) => {
+router.get("/user/:id",  async (req, res) => {
   try {
       const _id = req.params.id;  // Extracting userId from request params
 


### PR DESCRIPTION
a new route to get all event details, and an existing event detail route exists, which works perfectly for my event page. It won't affect the admin side. 

a new route to get detail of a single event for a detailed event page on the user side. 



